### PR TITLE
fix: update npm install command in workflows

### DIFF
--- a/.github/workflows/test-containarize-publish.yml
+++ b/.github/workflows/test-containarize-publish.yml
@@ -18,7 +18,7 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci --only=production
+      run: npm i
 
     - name: Run tests
       run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci --only=production
+      run: npm i
 
     - name: Run tests
       run: npm run test


### PR DESCRIPTION
Replace 'npm ci --only=production' with 'npm i' in GitHub
workflow files to ensure all dependencies are installed
properly. This change addresses issues with missing dev
dependencies during testing phases.