### PR TITLE
refactor(types): improve type safety and linting config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
-  ]
-}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,25 @@
+import typescript from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import js from '@eslint/js';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+    },
+    plugins: {
+      '@typescript-eslint': typescript,
+    },
+    rules: {
+      ...typescript.configs['recommended'].rules,
+    },
+  },
+  {
+    files: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
+    rules: {
+      // Add any additional rules here
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.10.0",
         "@types/node": "^22.5.5",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "test": "node --experimental-loader ts-node/esm --test \"test/**/*.test.ts\"",
-    "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "build": "tsc",
     "start": "node dist/app.js",
     "dev": "concurrently \"tsc --watch\" \"node --watch dist/app.js\""
@@ -28,6 +28,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.10.0",
     "@types/node": "^22.5.5",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.6.0",

--- a/src/plugins/dockerServiceUpdate.ts
+++ b/src/plugins/dockerServiceUpdate.ts
@@ -4,7 +4,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 const execAsync = promisify(exec);
 
-export interface DockerServiceUpdateOptions {}
+export type DockerServiceUpdateOptions = Record<string, unknown>;
 
 export default fp<DockerServiceUpdateOptions>(async (fastify: FastifyInstance) => {
 

--- a/src/plugins/jwtAuth.ts
+++ b/src/plugins/jwtAuth.ts
@@ -1,16 +1,18 @@
 import fp from 'fastify-plugin';
 import jwt from '@fastify/jwt';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { env } from 'process';
+import { SignPayloadType } from '@fastify/jwt';
 
 async function jwtAuth(fastify: FastifyInstance) {
   fastify.log.info('Registering JWT authentication plugin');
 
-  if (!process.env.JWT_SECRET) {
+  if (!env.JWT_SECRET) {
     throw new Error('JWT_SECRET environment variable is not set');
   }
 
   fastify.register(jwt, {
-    secret: process.env.JWT_SECRET
+    secret: env.JWT_SECRET
   });
 
   fastify.decorate('authenticate', async function(request: FastifyRequest, reply: FastifyReply) {
@@ -25,7 +27,7 @@ async function jwtAuth(fastify: FastifyInstance) {
 
   fastify.decorate('jwtUtils', {
     decode: (token: string) => fastify.jwt.decode(token),
-    sign: (payload: any) => fastify.jwt.sign(payload),
+    sign: (payload: SignPayloadType) => fastify.jwt.sign(payload),
     verify: (token: string) => fastify.jwt.verify(token)
   });
 
@@ -38,9 +40,9 @@ declare module 'fastify' {
   interface FastifyInstance {
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
     jwtUtils: {
-      sign: (payload: any) => string;
-      verify: (token: string) => any;
-      decode: (token: string) => string | null;
+      sign: (payload: SignPayloadType) => string;
+      verify: (token: string) => SignPayloadType;
+      decode: (token: string) => string | Record<string, unknown> | null;
     };
   }
 }

--- a/src/routes/update/index.ts
+++ b/src/routes/update/index.ts
@@ -20,7 +20,7 @@ const update: FastifyPluginAsync = async (fastify): Promise<void> => {
         }
       }
     },
-    handler: async (request, reply) => {
+    handler: async (request) => {
       const { appName } = request.body;
       fastify.log.info({ reqId: request.id, appName }, 'Received update request');
 

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,7 +1,8 @@
 // This file contains code that we reuse between our tests.
 import Fastify, { type FastifyInstance } from 'fastify'
+import { TestContext } from 'node:test'
 
-export default async function buildApp(t: any): Promise<FastifyInstance> {
+export default async function buildApp(t: TestContext): Promise<FastifyInstance> {
   const app: FastifyInstance = Fastify()
   // Tear down our app after we are done
   t.after(() => app.close())

--- a/test/plugins/dockerServiceUpdate.test.ts
+++ b/test/plugins/dockerServiceUpdate.test.ts
@@ -1,3 +1,4 @@
+import { env } from 'process';
 import { test } from 'node:test';
 import * as assert from 'node:assert';
 import Fastify, { type FastifyInstance } from 'fastify';
@@ -29,8 +30,8 @@ fi
 `, { mode: 0o755 });
 
 		// Modify PATH to include our fake docker
-		originalPath = process.env.PATH || '';
-		process.env.PATH = `${tmpDir}:${originalPath}`;
+		originalPath = env.PATH || '';
+		env.PATH = `${tmpDir}:${originalPath}`;
 
 		const { default: dockerServiceUpdate } = await import('../../src/plugins/dockerServiceUpdate.js');
 
@@ -40,7 +41,7 @@ fi
 
 	t.afterEach(async () => {
 		// Restore original PATH
-		process.env.PATH = originalPath;
+		env.PATH = originalPath;
 
 		// Clean up temporary directory
 		await fs.rm(tmpDir, { recursive: true, force: true });

--- a/test/plugins/jwtAuth.test.ts
+++ b/test/plugins/jwtAuth.test.ts
@@ -1,3 +1,4 @@
+import { env } from 'process';
 import { test } from 'node:test';
 import * as assert from 'node:assert';
 import Fastify, { type FastifyInstance } from 'fastify';
@@ -7,7 +8,7 @@ test('jwtAuth plugin', async (t) => {
   let fastify: FastifyInstance;
 
   t.beforeEach(async () => {
-    process.env.JWT_SECRET = 'test-secret';
+    env.JWT_SECRET = 'test-secret';
     fastify = Fastify();
   });
 
@@ -16,18 +17,13 @@ test('jwtAuth plugin', async (t) => {
   });
 
   await t.test('should register successfully', async () => {
-    try {
-      await fastify.register(jwtAuth);
-      assert.ok(fastify.jwt, 'fastify.jwt should be defined');
-      assert.ok(fastify.authenticate, 'fastify.authenticate should be defined');
-    } catch (error) {
-      console.error('Error in registration test:', error);
-      throw error;
-    }
+    await fastify.register(jwtAuth);
+    assert.ok(fastify.jwt, 'fastify.jwt should be defined');
+    assert.ok(fastify.authenticate, 'fastify.authenticate should be defined');
   });
 
   await t.test('should throw error if JWT_SECRET is not set', async () => {
-    delete process.env.JWT_SECRET;
+    delete env.JWT_SECRET;
     await assert.rejects(
       async () => {
         await fastify.register(jwtAuth);
@@ -41,8 +37,9 @@ test('jwtAuth plugin', async (t) => {
 
   await t.test('should sign and verify JWT', async () => {
     await fastify.register(jwtAuth);
+    interface TokenPayload { userId: number }
     const token = fastify.jwtUtils.sign({ userId: 1 });
-    const decoded = fastify.jwtUtils.verify(token);
+    const decoded = fastify.jwtUtils.verify(token) as TokenPayload;
     assert.equal(decoded.userId, 1);
   });
 

--- a/test/routes/update.test.ts
+++ b/test/routes/update.test.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from 'fastify';
+import { env } from 'process';
 import { test } from 'node:test';
 import * as assert from 'node:assert';
 import * as fs from 'fs/promises';
@@ -11,7 +12,7 @@ import dockerServiceUpdate from '../../src/plugins/dockerServiceUpdate.js'
 import update from '../../src/routes/update/index.js'
 
 test('update route', async (t) => {
-  process.env.JWT_SECRET = 'test-secret';
+  env.JWT_SECRET = 'test-secret';
   let tmpDir: string;
   let originalPath: string;
 
@@ -34,8 +35,8 @@ test('update route', async (t) => {
       fi
     `, { mode: 0o755 });
     // Modify PATH to include our fake docker
-    originalPath = process.env.PATH || '';
-    process.env.PATH = `${tmpDir}:${originalPath}`;
+    originalPath = env.PATH || '';
+    env.PATH = `${tmpDir}:${originalPath}`;
   })
 
   t.afterEach(async () => {


### PR DESCRIPTION
Replace `t: any` with `t: TestContext` in `buildApp` function to improve
type safety in tests. Update `sign` method in JWT plugin to use
`SignPayloadType` for better type safety. Migrate type `DockerServiceUpdateOptions`
to `Record<string, unknown>`. Consolidate `.eslintrc.json` into `eslint.config.js`,
and update `package.json` linting scripts for consistency. Replace direct usage
of `process.env` with `env` from `node:process` for better readability.