### PR TITLE
refactor: streamline Dockerfile dependency install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm -g install typescript
-RUN npm ci --only=production
+RUN npm install
 
 # Copy the rest of the application code
 COPY --chown=node:node . .


### PR DESCRIPTION
Remove global TypeScript installation and consolidate npm
commands to a single 'npm install'. This simplifies the build
process and ensures consistency in dependency resolution.