### PR TITLE
feat(ci): add container update trigger job in workflow

### DIFF
--- a/.github/workflows/test-containarize-publish.yml
+++ b/.github/workflows/test-containarize-publish.yml
@@ -60,3 +60,24 @@ jobs:
             ${{ vars.CONTAINER_REGISTRY_URL }}/codigo/${{ env.NAME }}:latest
           build-args: |
             JWT_SECRET=${{ secrets.JWT_SECRET }}
+
+  launch-update:
+    name: Trigger Container Update
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate Payload
+        uses: morzzz007/github-actions-jwt-generator@1.0.1
+        id: jwtGenerator
+        with:
+          secret: ${{ secrets.JWT_SECRET }}
+          payload: '{"appName":"${{ env.NAME }}"}'
+
+      - name: Trigger Update
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ vars.CONTAINER_UPDATER_URL }}/update
+          method: POST
+          customHeaders: '{ "Authorization": "Bearer ${{ steps.jwtGenerator.outputs.token }}", "Content-Type": "application/json"}'
+          data: '{"appName": "${{ env.NAME }}"}'


### PR DESCRIPTION
Adds a new job to the GitHub Actions workflow that triggers a container 
update after the build process. Generates a JWT payload using a secret 
and sends a POST request to the container updater URL with the necessary 
authorization and data payload. This change improves the CI process 
by automating the deployment of new container versions.