### PR TITLE
feat(package.json): mark project as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
   },
+  "private": true,
   "release": {
     "branches": [
       "main"


### PR DESCRIPTION
Sets the "private" flag to true in package.json to prevent the
accidental publication of the package to public registries. This
change ensures that the project remains a private collection of 
code, mitigating potential security risks and enforcing proper 
development practices.